### PR TITLE
Add support for Nova 7 WOW Edition alongside Arctis 7P

### DIFF
--- a/AllSound7P_ChatMix.py
+++ b/AllSound7P_ChatMix.py
@@ -44,12 +44,14 @@ class Arctis7PlusChatMix:
 
         # identify the arctis 7+ device
         try:
-            self.dev=usb.core.find(idVendor=0x1038, idProduct=0x220e)
+            # Support both Arctis 7P (0x220e) and Nova 7 WOW Edition (0x227a)
+            self.dev = usb.core.find(idVendor=0x1038, idProduct=0x220e) or \
+                        usb.core.find(idVendor=0x1038, idProduct=0x227a)
         except Exception as e:
             self.log.error("""Failed to identify the Arctis 7+ device.
             Please ensure it is connected.\n
             Please note: This program only supports the '7+' model.""")
-            self.die_gracefully(trigger)
+            self.die_gracefully(trigger="Couldn't find arctis7 model")
 
         # select its interface and USB endpoint, and capture the endpoint address
         try:
@@ -153,6 +155,7 @@ class Arctis7PlusChatMix:
 
         #route the virtual sink's L&R channels to the default system output's LR
         try:
+            default_sink = self.system_default_sink
             self.log.info("Assigning VAC sink monitors output to default device...")
 
             os.system(f'pw-link "ChatMix_Game:monitor_FL" '

--- a/Arctis_7_Plus_ChatMix.py
+++ b/Arctis_7_Plus_ChatMix.py
@@ -39,7 +39,9 @@ class Arctis7PlusChatMix:
 
         # identify the arctis 7+ device
         try:
-            self.dev=usb.core.find(idVendor=0x1038, idProduct=0x220e)
+            # Support both Arctis 7P (0x220e) and Nova 7 WOW Edition (0x227a)
+            self.dev = usb.core.find(idVendor=0x1038, idProduct=0x220e) or \
+                        usb.core.find(idVendor=0x1038, idProduct=0x227a)
         except Exception as e:
             self.log.error("""Failed to identify the Arctis 7+ device.
             Please ensure it is connected.\n

--- a/system-config/91-steelseries-arctis-7p.rules
+++ b/system-config/91-steelseries-arctis-7p.rules
@@ -1,5 +1,7 @@
 # TODO: use envsubst to fill in the appropriate $USER in install.sh
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="220e", OWNER="${USER}", GROUP="${USER}", MODE="0664"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="227a", OWNER="${USER}", GROUP="${USER}", MODE="0664"
 
 ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="220e", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/arctis7"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="227a", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/arctis7"
 ACTION=="remove", SUBSYSTEM=="usb", ENV{PRODUCT}=="1038/220e/*", TAG+="systemd"


### PR DESCRIPTION
- Add support for Nova 7 WOW Edition alongside Arctis 7P (could probably be done for other modern SteelSeries Headsets the same way.)
- Clean up some undefined variable warnings in AllSound7P_ChatMix.py